### PR TITLE
fix/#83 이미 지난 축제 즐겨찾기 알림 처리

### DIFF
--- a/src/main/java/inu/unithon/backend/domain/notification/entity/FestivalNotificationType.java
+++ b/src/main/java/inu/unithon/backend/domain/notification/entity/FestivalNotificationType.java
@@ -1,6 +1,6 @@
 package inu.unithon.backend.domain.notification.entity;
 
-import inu.unithon.backend.global.email.EmailService;
+import inu.unithon.backend.global.email.service.EmailService;
 import inu.unithon.backend.global.email.dto.FestivalEmailDto;
 
 /**

--- a/src/main/java/inu/unithon/backend/domain/notification/entity/FestivalStatus.java
+++ b/src/main/java/inu/unithon/backend/domain/notification/entity/FestivalStatus.java
@@ -1,0 +1,20 @@
+package inu.unithon.backend.domain.notification.entity;
+
+import java.time.LocalDateTime;
+
+public enum FestivalStatus {
+  PRE,     // 시작 전
+  ACTIVE,  // 진행 중
+  ENDED;   // 종료됨
+
+  public static FestivalStatus from(LocalDateTime now, LocalDateTime start, LocalDateTime end) {
+    if (now.isBefore(start)) {
+      return PRE;
+    } else if (now.isBefore(end)) {
+      return ACTIVE;
+    } else {
+      return ENDED;
+    }
+  }
+}
+

--- a/src/main/java/inu/unithon/backend/domain/notification/service/job/NotificationJob.java
+++ b/src/main/java/inu/unithon/backend/domain/notification/service/job/NotificationJob.java
@@ -6,7 +6,7 @@ import inu.unithon.backend.domain.member.entity.Member;
 import inu.unithon.backend.domain.member.service.MemberService;
 import inu.unithon.backend.domain.notification.entity.FestivalNotificationType;
 import inu.unithon.backend.domain.notification.repository.ScheduledJobRepository;
-import inu.unithon.backend.global.email.EmailService;
+import inu.unithon.backend.global.email.service.EmailService;
 import inu.unithon.backend.global.email.dto.FestivalEmailDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/inu/unithon/backend/domain/notification/service/reservation/NotificationReservationServiceImpl.java
+++ b/src/main/java/inu/unithon/backend/domain/notification/service/reservation/NotificationReservationServiceImpl.java
@@ -3,6 +3,7 @@ package inu.unithon.backend.domain.notification.service.reservation;
 import inu.unithon.backend.domain.festival.entity.Festival;
 import inu.unithon.backend.domain.festival.service.FestivalService;
 import inu.unithon.backend.domain.notification.entity.FestivalNotificationType;
+import inu.unithon.backend.domain.notification.entity.FestivalStatus;
 import inu.unithon.backend.domain.notification.entity.ScheduledJob;
 import inu.unithon.backend.domain.notification.policy.NotificationTimingPolicy;
 import inu.unithon.backend.global.scheduler.QuartzService;
@@ -14,7 +15,10 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static inu.unithon.backend.domain.notification.entity.FestivalNotificationType.END;
 import static inu.unithon.backend.domain.notification.entity.FestivalNotificationType.START;
+import static inu.unithon.backend.domain.notification.entity.FestivalStatus.ENDED;
+import static inu.unithon.backend.domain.notification.entity.FestivalStatus.PRE;
 
 @Slf4j
 @Service
@@ -27,24 +31,42 @@ public class NotificationReservationServiceImpl implements NotificationReservati
 
   @Override
   public void reserveAllNotifications(Long userId, Long festivalId) {
-
     Festival festival = festivalService.getFestival(festivalId);
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime startDate = festival.getStartDate();
+    LocalDateTime endDate = festival.getEndDate();
+
+    FestivalStatus status = FestivalStatus.from(now, startDate, endDate);
 
     for (NotificationTimingPolicy policy : timingPolicies) {  // 모든 알림 정책 순회
       FestivalNotificationType type = policy.getType();
 
+      // 축제 상태에 따라 필터링
+      if (status == FestivalStatus.ACTIVE) {
+        if (type == START) {
+          log.info("시작 알림 생략: 이미 시작된 축제");
+          continue;
+        }
+        // END는 가능
+      } else if (status == FestivalStatus.ENDED) {
+        log.info("모든 알림 생략: 이미 종료된 축제");
+        continue;
+      }
+
       // 중복 예약 방지
-      boolean alreadyExists = quartzService.existsJob(userId, festivalId, type);
-      if (alreadyExists) {
+      if (quartzService.existsJob(userId, festivalId, type)) {
         log.info("이미 예약된 알림입니다. userId={}, festivalId={}, type={}", userId, festivalId, type);
         continue;
       }
 
-      LocalDateTime targetDate = policy.getType() == START
-        ? festival.getStartDate()
-        : festival.getEndDate();
-
+      LocalDateTime targetDate = (type == START) ? startDate : endDate;
       LocalDateTime executeAt = policy.calculateExecuteAt(targetDate);
+
+      // 과거 시점 예약 생략
+      if (executeAt.isBefore(now)) {
+        log.info("과거 시점 알림 생략: executeAt={}", executeAt);
+        continue;
+      }
 
       ScheduledJob job = ScheduledJob.builder()
         .userId(userId)

--- a/src/main/java/inu/unithon/backend/global/email/service/EmailService.java
+++ b/src/main/java/inu/unithon/backend/global/email/service/EmailService.java
@@ -1,4 +1,4 @@
-package inu.unithon.backend.global.email;
+package inu.unithon.backend.global.email.service;
 
 import inu.unithon.backend.global.email.dto.FestivalEmailDto;
 

--- a/src/main/java/inu/unithon/backend/global/email/service/EmailServiceImpl.java
+++ b/src/main/java/inu/unithon/backend/global/email/service/EmailServiceImpl.java
@@ -1,4 +1,4 @@
-package inu.unithon.backend.global.email;
+package inu.unithon.backend.global.email.service;
 
 import inu.unithon.backend.global.email.dto.FestivalEmailDto;
 import inu.unithon.backend.global.exception.CustomException;


### PR DESCRIPTION
## 📖개요

<br>

필요시 실행결과 스크린샷 첨부
<br>
<img width="1397" height="115" alt="image" src="https://github.com/user-attachments/assets/fb1ba7c3-1840-47db-9ca8-bdbed196670e" />

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #83 
<br>
<br>

## 💻작업사항
축제가 이미 시작했을 때 : 축제 종료 알림만 발송
축제가 이미 종료됐을 때 : 아무런 알림 발송 하지 않음
- <br>

## 💡작성한 이슈 외에 작업한 사항

- <br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
